### PR TITLE
Fixes bug with direction containing february and m.Y format

### DIFF
--- a/public/javascript/zebra_datepicker.src.js
+++ b/public/javascript/zebra_datepicker.src.js
@@ -1577,10 +1577,9 @@
 
                         // check if date is a valid date (i.e. there's no February 31)
 
-                        var tmpdate = new Date(),
-                            original_day = tmpdate.getDate(),
-                            original_month = tmpdate.getMonth() + 1,
-                            original_year = tmpdate.getFullYear(),
+                        var original_day = 1,
+                            original_month = 1,
+                            original_year = 1979,
                             english_days   = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'],
                             english_months = ['January','February','March','April','May','June','July','August','September','October','November','December'],
                             iterable,


### PR DESCRIPTION
This patch fixes an edge case. The bug occurs if all of the following conditions are met:
1. The format does not contain a day, e.g. `m.Y`
2. The direction contains a boundary that has less than 31 days, e.g. `02.2014`
3. Today is the 31st.

If all 3 conditions are met, the `check_date('02.2014')` function returns `false` and that breaks the `direction`.

The bug occurred, because we tested for validity on **February 31st 2014**.
