### PR TITLE
Fixed a issue when closing the dp with a click on the target element is not working

### DIFF
--- a/public/javascript/zebra_datepicker.src.js
+++ b/public/javascript/zebra_datepicker.src.js
@@ -1326,9 +1326,9 @@
                             // (we want it to toggle the date picker)
                             if (plugin.settings.show_icon && $(e.target).get(0) === icon.get(0)) return true;
 
-                            // If the calender icon is not visible and we clicked the opener element, let the onClick event of the element to handle the event
+                            // If we clicked the opener element, let the onClick event of the element to handle the event
                             // (we want it to toggle the date picker)
-                            if (!plugin.settings.show_icon && $(e.target).get(0) === $element.get(0)) return true;
+                            if ($(e.target).get(0) === $element.get(0)) return true;
 
 
                             // if what's clicked is not inside the date picker

--- a/public/javascript/zebra_datepicker.src.js
+++ b/public/javascript/zebra_datepicker.src.js
@@ -1326,6 +1326,11 @@
                             // (we want it to toggle the date picker)
                             if (plugin.settings.show_icon && $(e.target).get(0) === icon.get(0)) return true;
 
+                            // If the calender icon is not visible and we clicked the opener element, let the onClick event of the element to handle the event
+                            // (we want it to toggle the date picker)
+                            if (!plugin.settings.show_icon && $(e.target).get(0) === $element.get(0)) return true;
+
+
                             // if what's clicked is not inside the date picker
                             // hide the date picker
                             if ($(e.target).parents().filter('.Zebra_DatePicker').length === 0) plugin.hide();
@@ -2761,7 +2766,7 @@
                 // execute the callback function
                 // make "this" inside the callback function refer to the element the date picker is attached to
                 plugin.settings.onSelect.call($element, selected_value, year + '-' + str_pad(month + 1, 2) + '-' + str_pad(day, 2), default_date, $element, getWeekNumber(default_date));
-                
+
             // move focus to the element the plugin is attached to
             $element.focus();
 


### PR DESCRIPTION
**Please note, it turned out that having the icon enabled or disabled make's no difference, the target element is never validated when closing the datepicker and therefore the datepicker get's opened again**

**Issue:** When a datapicker is open it can't be closed when the target element is clicked. A click to any other element on the page (except within the datepicker itself) or the icon (if used) will (correctly)  close the datepicker.

**Usecase:** Configure the datepicker, click the target field once to open the datepicker, click the target field again to close the datepicker.

**Expected result:** The datepicker should return to the closed state

**Actual result:** The datepicker is closed and opened again (very fast)

**Example:** http://jsfiddle.net/d2s5nvh1/1/